### PR TITLE
Add an index on gapsize

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -2,4 +2,5 @@ PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 CREATE TABLE gaps (gapsize INTEGER,ismax BOOLEAN,primecat TEXT,isfirst TEXT,primecert TEXT,discoverer TEXT,year INTEGER,merit REAL,primedigits INTEGER,startprime BLOB);
 CREATE TABLE credits (abbreviation TEXT,name TEXT,ack TEXT,display TEXT);
+CREATE INDEX IF NOT EXISTS gaps_gapsize ON gaps (gapsize);
 COMMIT;


### PR DESCRIPTION
This speeds up queries on gapsize 

```
$ rm gaps.db 
$ sqlite3 gaps.db < allgaps.sql 

$ sqlite3 gaps.db 
sqlite> .timer ON
sqlite> select * from gaps where gapsize in (100, 1000, 1432, 1550, 10000, 100000, 1000000);
gapsize|ismax|primecat|isfirst|primecert|discoverer|year|merit|primedigits|startprime
100|0|C|F|C|Glaisher|1877|7.76|6|396733
1000|0|C|F|C|Be.Nyman|2001|26.56|17|22439962446379651
1432|0|C|?|C|Spielaur|2011|27.13|23|84218359021503505748941
1550|1|C|F|C|Be.Nyman|2014|34.94|20|18361375334787046697
10000|0|C|?|C|Jacobsen|2015|30.01|145|199515017*347#/30 - 5524
100000|0|C|?|P|Jacobsen|2016|20.07|2164|33823*5059#/7410 - 31102
Run Time: real 0.010 user 0.004716 sys 0.005893

sqlite> CREATE INDEX gaps_gapssize ON gaps (gapsize);
Run Time: real 0.044 user 0.024700 sys 0.007053

sqlite> select * from gaps where gapsize in (100, 1000, 1432, 1550, 10000, 100000, 1000000);
gapsize|ismax|primecat|isfirst|primecert|discoverer|year|merit|primedigits|startprime
100|0|C|F|C|Glaisher|1877|7.76|6|396733
1000|0|C|F|C|Be.Nyman|2001|26.56|17|22439962446379651
1432|0|C|?|C|Spielaur|2011|27.13|23|84218359021503505748941
1550|1|C|F|C|Be.Nyman|2014|34.94|20|18361375334787046697
10000|0|C|?|C|Jacobsen|2015|30.01|145|199515017*347#/30 - 5524
100000|0|C|?|P|Jacobsen|2016|20.07|2164|33823*5059#/7410 - 31102
Run Time: real 0.000 user 0.000155 sys 0.000078
```